### PR TITLE
Fix lint warnings and cleanup logs

### DIFF
--- a/src/components/AiRobot.tsx
+++ b/src/components/AiRobot.tsx
@@ -13,7 +13,7 @@ const AiRobot: React.FC<AiRobotProps> = ({ className = "" }) => {
     if (!robot) return;
     
     // Simple animation effect
-    let bounceInterval = setInterval(() => {
+    const bounceInterval = setInterval(() => {
       robot.style.transform = "translateY(-3px)";
       setTimeout(() => {
         if (robot) robot.style.transform = "translateY(0)";

--- a/src/components/BenefitsSection.tsx
+++ b/src/components/BenefitsSection.tsx
@@ -17,12 +17,13 @@ const BenefitsSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/CtaSection.tsx
+++ b/src/components/CtaSection.tsx
@@ -14,7 +14,6 @@ const CtaSection = () => {
     // In a real implementation, this would send data to a backend
     // For now, just simulate success
     setSubmitted(true);
-    console.log("User signup:", { email, userType });
   };
 
   return (

--- a/src/components/GroupBiddingSection.tsx
+++ b/src/components/GroupBiddingSection.tsx
@@ -18,12 +18,13 @@ const GroupBiddingSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -17,12 +17,13 @@ const HowItWorksSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/MissionSection.tsx
+++ b/src/components/MissionSection.tsx
@@ -19,12 +19,13 @@ const MissionSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/PainPointsSection.tsx
+++ b/src/components/PainPointsSection.tsx
@@ -17,12 +17,13 @@ const PainPointsSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/ProblemSection.tsx
+++ b/src/components/ProblemSection.tsx
@@ -17,12 +17,13 @@ const ProblemSection = () => {
       { threshold: 0.1 }
     );
 
-    elementsRef.current.forEach((el) => {
+    const elements = elementsRef.current;
+    elements.forEach((el) => {
       if (el) observer.observe(el);
     });
 
     return () => {
-      elementsRef.current.forEach((el) => {
+      elements.forEach((el) => {
         if (el) observer.unobserve(el);
       });
     };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/tools/AgentsMadeEasy.tsx
+++ b/src/pages/tools/AgentsMadeEasy.tsx
@@ -5,8 +5,38 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Check, Calendar, Calculator, TrendingUp } from "lucide-react";
 
+interface PricingPlan {
+  name: string;
+  price: number;
+  featured: boolean;
+  features: string[];
+}
+
+interface Slot {
+  date: string;
+  time: string;
+}
+
+interface Step {
+  name: string;
+  description: string;
+  completed: boolean;
+}
+
+interface Metrics {
+  hoursPerWeek: number;
+  hourlyRate: number;
+  cost: number;
+}
+
+type DynamicComponent =
+  | { type: "pricing"; data: PricingPlan[] }
+  | { type: "calendar"; data: Slot[] }
+  | { type: "progress"; data: Step[] }
+  | { type: "roi"; data: Metrics };
+
 // Pricing Table Component
-function PricingTable({ plans }: { plans: any[] }) {
+function PricingTable({ plans }: { plans: PricingPlan[] }) {
   return (
     <motion.div 
       initial={{ opacity: 0, y: 20 }}
@@ -38,7 +68,7 @@ function PricingTable({ plans }: { plans: any[] }) {
 }
 
 // Booking Calendar Component
-function BookingCalendar({ slots }: { slots: any[] }) {
+function BookingCalendar({ slots }: { slots: Slot[] }) {
   return (
     <motion.div 
       initial={{ opacity: 0, scale: 0.9 }}
@@ -64,7 +94,7 @@ function BookingCalendar({ slots }: { slots: any[] }) {
 }
 
 // Progress Indicator Component
-function ProgressIndicator({ steps }: { steps: any[] }) {
+function ProgressIndicator({ steps }: { steps: Step[] }) {
   return (
     <motion.div 
       initial={{ opacity: 0, x: -20 }}
@@ -92,7 +122,7 @@ function ProgressIndicator({ steps }: { steps: any[] }) {
 }
 
 // ROI Calculator Component
-function ROICalculator({ metrics }: { metrics: any }) {
+function ROICalculator({ metrics }: { metrics: Metrics }) {
   const savings = metrics.hoursPerWeek * metrics.hourlyRate * 52;
   const roi = ((savings - metrics.cost) / metrics.cost * 100).toFixed(0);
   
@@ -127,7 +157,7 @@ function ROICalculator({ metrics }: { metrics: any }) {
 
 // Main Component with Generative UI
 function AgentsMadeEasyContent() {
-  const [dynamicComponents, setDynamicComponents] = useState<any[]>([]);
+  const [dynamicComponents, setDynamicComponents] = useState<DynamicComponent[]>([]);
   
   // Get the chat messages to analyze for UI triggers
   const { messages } = useCopilotChat();
@@ -268,7 +298,13 @@ function AgentsMadeEasyContent() {
         }
       }
     }
-  }, [messages]);
+  }, [
+    messages,
+    showPricingTable,
+    showBookingCalendar,
+    showProgressIndicator,
+    showROICalculator,
+  ]);
 
   return (
     <div className="flex h-screen">

--- a/src/pages/tools/SalesBot.tsx
+++ b/src/pages/tools/SalesBot.tsx
@@ -22,27 +22,28 @@ const SalesBot = () => {
   // Generate or retrieve thread ID
   useEffect(() => {
     const storedThreadId = localStorage.getItem("salesbot-thread-id");
+
+    const initialMessage: Message = {
+      role: "assistant",
+      content: "Hi! I'm here to help you get started with InstaBids. What kind of home improvement project are you planning?",
+    };
+
     if (storedThreadId) {
       setThreadId(storedThreadId);
-      // Load stored messages
       const storedMessages = localStorage.getItem(`salesbot-messages-${storedThreadId}`);
       if (storedMessages) {
         setMessages(JSON.parse(storedMessages));
+      } else {
+        setMessages([initialMessage]);
       }
     } else {
       const newThreadId = `thread-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
       localStorage.setItem("salesbot-thread-id", newThreadId);
       setThreadId(newThreadId);
-    }
-
-    // Add initial message
-    if (messages.length === 0) {
-      setMessages([{
-        role: "assistant",
-        content: "Hi! I'm here to help you get started with InstaBids. What kind of home improvement project are you planning?"
-      }]);
+      setMessages([initialMessage]);
     }
   }, []);
+
 
   // Save messages to localStorage whenever they change
   useEffect(() => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -120,5 +121,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+    plugins: [animate],
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,10 @@ export default defineConfig(({ mode }) => ({
                 const response = data.response || data.message || "";
                 
                 // Pattern matching for UI generation
-                let actions = [];
+                const actions = [] as Array<{
+                  name: string;
+                  args: unknown;
+                }>;
                 
                 if (response.toLowerCase().includes('pricing') || response.toLowerCase().includes('plans')) {
                   actions.push({


### PR DESCRIPTION
## Summary
- preserve local element references when cleaning up IntersectionObserver
- type dynamic UI structures in AgentsMadeEasy
- rewrite SalesBot initialization to preload the assistant message
- switch Tailwind animate plugin to ES module import
- remove leftover console log
- add newline at EOF for SalesBot component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a2398e50c8333a699f764066a714c